### PR TITLE
Revoke BuildSecret Deletion

### DIFF
--- a/.github/workflows/flutter-build.yml
+++ b/.github/workflows/flutter-build.yml
@@ -38,6 +38,10 @@ env:
   #signing keys env variable checks
   ANDROID_SIGNING_KEY: "${{ secrets.ANDROID_SIGNING_KEY }}"
   MACOS_P12_BASE64: "${{ secrets.MACOS_P12_BASE64 }}"
+  # To make a custom build with your own servers set the below secret values
+  RS_PUB_KEY: "${{ secrets.RS_PUB_KEY }}"
+  RENDEZVOUS_SERVER: "${{ secrets.RENDEZVOUS_SERVER }}"
+  API_SERVER: "${{ secrets.API_SERVER }}"
   UPLOAD_ARTIFACT: "${{ inputs.upload-artifact }}"
   SIGN_BASE_URL: "${{ secrets.SIGN_BASE_URL }}"
 


### PR DESCRIPTION
Good day to you,

we are building our own client via githubactions and noticed that our custom relay/api/key isnt integrated into the executables anymore.

[25f917a](https://github.com/rustdesk/rustdesk/pull/10614)

I suppose this patch removed the feature to set the custom values via githubsecrets and propose to revert that change or provide another possibility to achive it.
Of course some bad guys can use it, to build their own rustdesk client, but they can anyways, eg. by simply using an old version for their client and server. So why remove it. It only hurts the wrong folks...